### PR TITLE
ELOレーティングをAPI経由で管理する

### DIFF
--- a/.github/workflows/battle_between_AIs.yml
+++ b/.github/workflows/battle_between_AIs.yml
@@ -14,13 +14,12 @@ on:
         description: "Number of matches"
         required: false 
         default: 1
-env:
-  BASIC_USER: ${{ secrets.BASIC_USER }}
-  BASIC_PASSWORD: ${{ secrets.BASIC_PASSWORD }}
 
 jobs:
   Buttle-Between-AIs:
     runs-on: ubuntu-latest
+    environment:
+      name: BASIC_AUTH
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -34,5 +33,8 @@ jobs:
         run: |
           poetry install
       - name: Run Ktuarto
+        env:
+          BASIC_USER: ${{ secrets.BASIC_USER }}
+          BASIC_PASSWORD: ${{ secrets.BASIC_PASSWORD }}
         run: |
           poetry run ktuarto run ${{ github.event.inputs.your_ai }} ${{ github.event.inputs.opponent_ai }} --matches ${{ github.event.inputs.matches }}

--- a/.github/workflows/battle_between_AIs.yml
+++ b/.github/workflows/battle_between_AIs.yml
@@ -31,5 +31,8 @@ jobs:
         run: |
           poetry install
       - name: Run Ktuarto
+        env:
+          BASIC_USER: ${{secrets.BASIC_USER}}
+          BASIC_PASSWORD: ${{secrets.BASIC_PASSWORD}}
         run: |
           poetry run ktuarto run ${{ github.event.inputs.your_ai }} ${{ github.event.inputs.opponent_ai }} --matches ${{ github.event.inputs.matches }}

--- a/.github/workflows/battle_between_AIs.yml
+++ b/.github/workflows/battle_between_AIs.yml
@@ -14,6 +14,9 @@ on:
         description: "Number of matches"
         required: false 
         default: 1
+env:
+  BASIC_USER: ${{ secrets.BASIC_USER }}
+  BASIC_PASSWORD: ${{ secrets.BASIC_PASSWORD }}
 
 jobs:
   Buttle-Between-AIs:
@@ -31,8 +34,5 @@ jobs:
         run: |
           poetry install
       - name: Run Ktuarto
-        env:
-          BASIC_USER: ${{secrets.BASIC_USER}}
-          BASIC_PASSWORD: ${{secrets.BASIC_PASSWORD}}
         run: |
           poetry run ktuarto run ${{ github.event.inputs.your_ai }} ${{ github.event.inputs.opponent_ai }} --matches ${{ github.event.inputs.matches }}

--- a/ktuarto/utils/gamemain.py
+++ b/ktuarto/utils/gamemain.py
@@ -180,7 +180,7 @@ def winningPercentageRun(gamenum, p0=None, p1=None):
         None:0,
     }
     scoreper = {}
-    elo = {player0:1500, player1:1500}
+    elo = {player0: 0, player1: 0}
 
     for i in range(gamenum):
         #ゲーム実行
@@ -192,12 +192,12 @@ def winningPercentageRun(gamenum, p0=None, p1=None):
         util.p.print('後攻 player1：'+str(player1))
         if (res == 0):
             util.p.print('勝利AI：'+str(player0))
-            elo[player0], elo[player1] = rating.calcEloRating(elo[player0], elo[player1], 1, 0)
+            elo[player0], elo[player1] = rating.calcEloRating(player0.__class__.__name__, player1.__class__.__name__, 1, 0)
         elif (res == 1):
             util.p.print('勝利AI：'+str(player1))
-            elo[player0], elo[player1] = rating.calcEloRating(elo[player0], elo[player1], 0, 1)
+            elo[player0], elo[player1] = rating.calcEloRating(player0.__class__.__name__, player1.__class__.__name__, 0, 1)
         else:
-            elo[player0], elo[player1] = rating.calcEloRating(elo[player0], elo[player1], 0.5, 0.5)
+            elo[player0], elo[player1] = rating.calcEloRating(player0.__class__.__name__, player1.__class__.__name__, 0.5, 0.5)
         util.p.print('')
         
         #スコア加算

--- a/ktuarto/utils/rating.py
+++ b/ktuarto/utils/rating.py
@@ -49,7 +49,7 @@ def calcEloRating (PlayerAName, PlayerBName, winNumberPlayerA, winNumberPlayerB,
 
 def initElo(name):
     requests.post(
-            "http://localhost:3001/api/v1/ais",
+            "http://quarto.unigiri.net:3001/api/v1/ais",
             headers = headers,
             data = json.dumps({'name': name}),
             auth = basicAuth
@@ -57,7 +57,7 @@ def initElo(name):
 
 def getElo(name):
     response = requests.get(
-            f'http://localhost:3001/api/v1/ais/{name}',
+            f'http://quarto.unigiri.net:3001/api/v1/ais/{name}',
             headers = headers,
             auth = basicAuth
             )
@@ -65,7 +65,7 @@ def getElo(name):
 
 def updateElo(name, elo):
     requests.put(
-            f"http://localhost:3001/api/v1/ais/{name}",
+            f"http://quarto.unigiri.net:3001/api/v1/ais/{name}",
             headers = headers,
             data = json.dumps({'elo': elo}),
             auth = basicAuth

--- a/ktuarto/utils/rating.py
+++ b/ktuarto/utils/rating.py
@@ -1,5 +1,19 @@
 # coding: UTF-8
-def calcEloRating (eloPlayerA, eloPlayerB, winNumberPlayerA, winNumberPlayerB, K=32):
+
+import os
+import json
+import requests
+from requests.auth import HTTPBasicAuth
+from dotenv import load_dotenv
+
+load_dotenv()
+headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+        }
+basicAuth = HTTPBasicAuth(os.getenv('BASIC_USER'), os.getenv('BASIC_PASSWORD'))
+
+def calcEloRating (PlayerAName, PlayerBName, winNumberPlayerA, winNumberPlayerB, K=32):
     """calcEloRating (eloPlayerA, eloPlayerB, winNumberPlayerA, winNumberPlayerBw K=32)
 
     ELOレーティングを計算します。PlayerAとPlayerBについて同時に算出します。
@@ -14,6 +28,12 @@ def calcEloRating (eloPlayerA, eloPlayerB, winNumberPlayerA, winNumberPlayerB, K
     Returns:
         (calcedEloPlayerA, calcedEloPlayerB): 各プレイヤーの試合後ELOレーティングをタプルで返します。
     """
+
+    initElo(PlayerAName)
+    initElo(PlayerBName)
+    eloPlayerA = getElo(PlayerAName)
+    eloPlayerB = getElo(PlayerBName)
+
     # winRateAtoBはAの予測勝率、winRateBtoAはBの予測勝率
     winRateAtoB = 1/(pow(10,(float(eloPlayerB) - float(eloPlayerA))/400) + 1)
     winRateBtoA = 1 - winRateAtoB
@@ -21,5 +41,32 @@ def calcEloRating (eloPlayerA, eloPlayerB, winNumberPlayerA, winNumberPlayerB, K
     # ELO更新
     newEloPlayerA = int(round(eloPlayerA + K * (winNumberPlayerA - gameNumber * winRateAtoB)))
     newEloPlayerB = int(round(eloPlayerB + K * (winNumberPlayerB - gameNumber * winRateBtoA)))
+
+    updateElo(PlayerAName, newEloPlayerA)
+    updateElo(PlayerBName, newEloPlayerB)
     
     return (newEloPlayerA,newEloPlayerB)
+
+def initElo(name):
+    requests.post(
+            "http://localhost:3001/api/v1/ais",
+            headers = headers,
+            data = json.dumps({'name': name}),
+            auth = basicAuth
+            )
+
+def getElo(name):
+    response = requests.get(
+            f'http://localhost:3001/api/v1/ais/{name}',
+            headers = headers,
+            auth = basicAuth
+            )
+    return response.json()['ai']['elo']
+
+def updateElo(name, elo):
+    requests.put(
+            f"http://localhost:3001/api/v1/ais/{name}",
+            headers = headers,
+            data = json.dumps({'elo': elo}),
+            auth = basicAuth
+            )

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,25 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.9"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "click"
 version = "8.0.1"
 description = "Composable command line interface toolkit"
@@ -38,6 +57,14 @@ description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "more-itertools"
@@ -116,6 +143,48 @@ checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dotenv"
+version = "0.19.2"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
+name = "requests"
+version = "2.26.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "urllib3"
+version = "1.26.7"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -126,7 +195,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.11"
-content-hash = "4b74f6251832b691067e11fb39913fb4b17a88bb25ff8c2b6cb67b9ae6edf13e"
+content-hash = "e8d72982236d0d24967e6ad50f9bbec3b7763edebad10c935c32b3fcfac87f8d"
 
 [metadata.files]
 atomicwrites = [
@@ -137,6 +206,14 @@ attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
+    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
+]
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
     {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
@@ -144,6 +221,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 more-itertools = [
     {file = "more-itertools-8.8.0.tar.gz", hash = "sha256:83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a"},
@@ -200,6 +281,18 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},
+    {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
+]
+requests = [
+    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
+    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
+    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ authors = ["Unigiri Unini <me@unigiri.net>"]
 python = ">=3.9,<3.11"
 numpy = "^1.21.2"
 click = "^8.0.1"
+python-dotenv = "^0.19.2"
+requests = "^2.26.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
現状ELOレーティングとして仮の値を与えているところを、[API](http://quarto.unigiri.net:3001/)経由でELOレーティングの取得、更新、初期化を行う
これによりELOレーティングを外部のサーバに保存しておくことができ、計算時にそれを利用することができる。

この外部のサーバにアクセスするには、Basic認証のユーザ名とパスワードが必要。
これはGitHub Actions経由であればGitHubの設定から設定可能。
手元で実行した結果を反映させる場合は、秘密のユーザ名とパスワードをDM等で受け渡す必要がある。

### GitHub Actions経由での設定方法

上部メニューから `Setting > Secrets` を選択し、右上の `New repository secret` をクリック (嘘かもしれない)

![image](https://user-images.githubusercontent.com/42710327/144746827-cc99bfc8-48a8-4b11-b93f-1c397b90c25a.png)

Environment名として `BASIC_AUTH` と入力する

![image](https://user-images.githubusercontent.com/42710327/144746879-6fd61e15-8411-4d1e-a867-f93136bb6285.png)

`Environment secrets` の `Add Secret` をクリック

![image](https://user-images.githubusercontent.com/42710327/144746916-bc5b020a-9654-429a-91af-b6c2ae7660c0.png)

このポップアップでNameとして `BASIC_USER` と入力する。Valueは別途伝える。

![image](https://user-images.githubusercontent.com/42710327/144746950-e4086550-ff40-4259-9c43-44e39c5dea5d.png)

同様の手順でName: `BASIC_PASSWORD` も作成する。Valueも同じく別途伝える。

以上によりGitHub Actions経由でELOスコア票の更新が可能になる。