### PR TITLE
ELOの保存先をFirestoreへ変更

### DIFF
--- a/.github/workflows/battle_between_AIs.yml
+++ b/.github/workflows/battle_between_AIs.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   Buttle-Between-AIs:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: 'write'
     environment:
       name: BASIC_AUTH
     steps:
@@ -32,6 +34,13 @@ jobs:
       - name: Build Ktuarto
         run: |
           poetry install
+      - id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: 'projects/627953691048/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+          service_account: 'github-actions-service-account@quartobattlestation.iam.gserviceaccount.com'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
       - name: Run Ktuarto
         env:
           BASIC_USER: ${{ secrets.BASIC_USER }}

--- a/.github/workflows/battle_between_AIs.yml
+++ b/.github/workflows/battle_between_AIs.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: 'write'
-    environment:
-      name: BASIC_AUTH
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -42,8 +40,5 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - name: Run Ktuarto
-        env:
-          BASIC_USER: ${{ secrets.BASIC_USER }}
-          BASIC_PASSWORD: ${{ secrets.BASIC_PASSWORD }}
         run: |
           poetry run ktuarto run ${{ github.event.inputs.your_ai }} ${{ github.event.inputs.opponent_ai }} --matches ${{ github.event.inputs.matches }}

--- a/ktuarto/AI/__init__.py
+++ b/ktuarto/AI/__init__.py
@@ -1,3 +1,5 @@
 from .sample_ai import SampleAi
 from .random_ai import RandomAi, RandomAi2, RandomAi3
 from .montecarlo_ai import Montecarlo
+from .montecarlo_choose_diagonal_lines_first import MontecarloChooseDiagonalLinesFirst
+from .montecarlo_choose_places_other_than_diagonal_lines_first import MontecarloChoosePlacesOtherThanGiagonalLinesFirst

--- a/ktuarto/AI/montecarlo_choose_diagonal_lines_first.py
+++ b/ktuarto/AI/montecarlo_choose_diagonal_lines_first.py
@@ -1,0 +1,547 @@
+from . import base_ai
+from ..utils import ucb1, board, box, piece, util
+
+import numpy as np
+import time
+
+class Parameter:
+    def __init__(self):
+        self.playoutTimelimit = 1   #プレイアウトの時間制限
+        self.ucb1_c = 1.0           #ucb1のc定数
+        self.ucb1_fpu = 100         #fpu値
+        self.playoutDepthBorder = 4 #プレイアウトをさらに深くする閾値   -1はチェックしない
+        self.putCgt = 10
+        self.choiceCgt = 11
+        #self.putCgt = 0
+        #self.choiceCgt = 0
+
+class MontecarloChooseDiagonalLinesFirst(base_ai.BaseAi):
+    """
+    ゲーム木を生成するクラス
+    内容は適当な値を返す処理を記述
+    callだけは判定する
+    """
+    def __init__(self):
+        self.param = Parameter()
+        
+    def choice(self, in_board, in_box):
+        """
+        in_boxリストにある最初の１つを返す
+        """
+        in_board = board.HiTechBoard(in_board)    #List, Dict形式のデータをBoardクラスに変換
+        in_box = box.Box(in_box)            #List, Dict形式のデータをBoxクラスに変換
+
+        
+        if len(in_box.piecelist) == 16 :
+            #負荷軽減のため、最初の一手はランダムで返す。（どれ選んでも同じでしょ、思考させるだけ無駄）
+            randnum = np.random.randint( len(in_box.piecelist) )
+            res_piece = in_box.piecelist[randnum]
+
+        else:
+            #モンテカルロロジック実行
+            branchinfo = MonteBranchInfo(in_board, in_box, None, True, self.param)
+            res_piece = branchinfo.runChoice()
+        
+        res_piece = res_piece.toDict()
+            
+        #callの判定
+        res_call = "Quarto" if in_board.isQuarto() else "Non"
+
+        return {\
+            'piece':res_piece,\
+            'call':res_call,\
+        }
+    
+    def put(self, in_board, in_piece):
+        """
+        in_boardからまだピースが置かれていない座標を返す
+        """
+        in_board = board.HiTechBoard(in_board)          #List, Dict形式のデータをBoardクラスに変換
+        in_piece = piece.Piece.getInstance(in_piece)    #Dict形式のデータをBoardクラスに変換
+        
+        #Boxを生成
+        in_box = box.Box(board=in_board)
+        in_box.remove(in_piece)
+
+        #モンテカルロ木探索を行う。
+        branchinfo = MonteBranchInfo(in_board, in_box, in_piece, True, self.param)
+        res_left, res_top = branchinfo.runPut()
+        
+        #置いたときのクアルト判定
+        in_board.setBoard(res_left, res_top, in_piece)
+        res_call = "Quarto" if in_board.isQuarto() else "Non"
+
+        return {\
+            'call':res_call,\
+            'left':res_left,\
+            'top':res_top,\
+        }
+
+class MonteBranchRand:
+    """
+    モンテカルロ法の乱数処理部分
+    """
+    def __init__(self, board, box, piece, myturn):
+        self.board = board
+        self.box = box
+        self.piece = piece
+        self.myturn = myturn
+        self.winner = None
+    
+    def run(self):
+        while(self.winner is None):
+            #駒がなければchoice
+            if (self.piece is None):
+                #choice前、boxが空ならゲーム終了なのでループを出る。
+                if(len(self.box.piecelist)==0):
+                    break
+
+                self.choiceRand()
+                self.myturn = not self.myturn #choiceの後プレイヤーを交代
+
+            #駒があればput
+            else:
+                self.putRand()
+
+                #put後、boxが空ならゲーム終了なのでループを出る。
+                if(len(self.box.piecelist)==0):
+                    break
+        
+        #勝者を返す
+        return self.winner
+    
+    def putRand(self):
+        #このputで勝てる場合、自分が勝って終了
+        if(util.endPiece(self.board, self.piece)):
+            self.winner = self.myturn
+            return
+        
+        checkpattern = util.losePiecePos2(self.board,self.box,self.piece)
+
+        #選択肢が残っていなければ負けを返す
+        if ( not np.any(checkpattern) ):
+            self.winner = not self.myturn
+            return
+
+        patternlist = np.where(checkpattern)
+        
+        #乱数生成
+        randnum = np.random.randint(patternlist[0].size)
+
+        #手を進める
+        self.board.setBoard(patternlist[0][randnum], patternlist[1][randnum], self.piece)
+        
+        #選んだ駒を空にする
+        self.piece = None
+
+    def choiceRand(self):
+        #勝ち目のあるピースを取得
+        oddspieces = util.oddsPieces(self.board, self.box.piecelist)
+
+        #どれを選んでも負ける場合
+        patternsize = len(oddspieces)
+        if (patternsize == 0):
+            self.winner = not self.myturn   #相手の勝ち
+            return
+
+        #乱数生成
+        randnum = np.random.randint( patternsize )
+
+        #駒を選択
+        self.piece = oddspieces[randnum]
+
+        #boxから駒をはずす。
+        self.box.remove(self.piece)
+
+class DammyBranch:
+    """
+    MonteBranchRandのonLeafメソッドを仮で行うためのクラス
+    if(self.parent is not None)で毎回チェックをなくすための処置
+    """
+    def __init__(self):
+        self.myturn = True
+        self.winner = False
+        self.isLeaf = False
+        self.branchlostcounter = 0
+        self.leafcounter = 0
+        self.branchnum = 1
+    
+    def onLeaf(self):
+        pass
+
+class MonteBranchInfo:
+    
+    def __init__(self, board, box, piece, myturn, param, parent=DammyBranch()):
+        self.board = board              #ボード
+        self.box = box                  #ボックス
+        self.piece = piece              #駒
+        self.myturn = myturn            #ターン（trueが自分）
+        self.param = param              #プレイアウト試行回数
+
+        self.branchList = None          #ブランチリスト
+        self.left = None                #putのleft座標
+        self.top = None                 #putのtop座標
+        
+        self.branchnum = 0              #ブランチの数
+        self.branchPlayoutCount = None  #ブランチプレイアウト数（numpy配列）
+        self.branchPlayoutWin = None    #ブランチプレイアウト勝利数（numpy配列）
+        self.branchPlayoutDraw = None   #ブランチプレイアウト引分数（numpy配列）
+        self.branchPlayoutTotal = 0     #ブランチプレイアウトの合計（数値）
+
+        self.branchPlayoutTarget = 0    #ブランチプレイアウトを行う対象
+        self.branchlostcounter = 0      #負けブランチの数をカウントする
+        self.leafcounter = 0            #枝が葉になった数をカウントする
+
+        self.isLeaf = False             #ゲーム葉フラグ。ゲームの決着がついたフラグ。gameoverとほぼ同義
+        self.winner = None              #ゲームの勝者
+        self.parent = parent            #親ブランチ
+
+    def runChoice(self):
+        #ブランチ生成
+        cgtflag = len(np.where(self.board.onboard != None)[0]) >= self.param.choiceCgt
+        self.createChoiceBranch(cgtflag)
+
+        #勝てる手がなければ（ブランチがなければ）先頭を返す。
+        if( self.branchList is None ):return self.box.piecelist[0]
+        
+        #ルート探査
+        topScoreIndex = self.searchRoute()
+        return self.branchList[topScoreIndex].piece
+    
+    def runPut(self):
+        #このputで勝てる場合、勝てる手を選んで終了
+        if(util.endPiece(self.board, self.piece)):
+            return util.endPiecePos(self.board, self.piece)  #戻り値はleft, topの二つ
+        
+        #ブランチの生成
+        cgtflag = len(np.where(self.board.onboard != None)[0]) >= self.param.putCgt
+        self.createPutBranch(cgtflag)
+
+        #勝てる手がなければ（ブランチがなければ）先頭を返す。
+        if( self.branchList is None ):
+            index = np.where(self.board.onboard == None)
+            return index[0][0], index[1][0]
+
+        #ルート探査
+        topScoreIndex = self.searchRoute()
+        return self.branchList[topScoreIndex].left, self.branchList[topScoreIndex].top
+
+    def createChoiceBranch(self, cgtflag):
+        """
+        ゲーム木生成処理（choice）
+        cgtflag：Trueのとき完全ゲーム木を生成する。
+        """
+        #駒が無ければ終了
+        if(len(self.box.piecelist)==0):
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        #勝ち目の無い選択を減らす
+        oddspieces = util.oddsPieces(self.board, self.box.piecelist)
+
+        #ブランチの数を設定
+        self.branchnum = len(oddspieces)
+
+        #手がなかったら何もしない
+        if(self.branchnum == 0):
+            self.winner = not self.myturn   #相手の勝ち
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        self.branchList = []
+        for p in oddspieces:
+            tbox = self.box.clone()
+            tbox.remove(p)
+            bi = MonteBranchInfo(
+                self.board.clone(),     #現状のボードのクローンを渡す
+                tbox,                   #次の想定の残り駒を渡す
+                p,                      #次の想定のピースを渡す
+                not self.myturn,        #相手プレイヤーの手版になる
+                self.param,             #パラメータ
+                self
+            )
+            self.branchList.append(bi)
+        
+        if(cgtflag):
+            #choiceの完全ゲーム木探索
+            self.createChoiceCgt()
+
+        else:
+            #プレイアウトのための初期化
+            self.playoutinit()
+    
+    def createChoiceCgt(self):
+        """
+        完全ゲーム木探索処理（choice）
+        """
+        #枝の成長と勝敗の判定
+        for bi in self.branchList:
+            
+            #先のput枝生成
+            bi.createPutBranch(True)
+            bi.branchList = None    #debug
+            
+            #ブランチを生成し、それがisLeafとなるとonLeafメソッドが実行される。
+            #それをチェックして葉になっていたら終了
+            if(self.isLeaf): break
+
+
+    def createPutBranch(self, cgtflag):
+        """
+        ゲーム木生成処理（put）
+        cgtflag：Trueのとき完全ゲーム木を生成する。
+        """
+        #このputで勝てる場合、自分が勝って終了
+        if(util.endPiece(self.board, self.piece)):
+            self.winner = self.myturn
+            self.isLeaf = True
+            self.onLeaf()
+            return
+        
+        #駒が無ければ終了
+        if(len(self.box.piecelist)==0):
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        #勝ち目のある駒のない箇所のインデックス一覧を取得
+        checkpattern = util.losePiecePos2(self.board,self.box,self.piece)
+        patternlist = np.where(checkpattern)
+        
+        #ブランチの数を設定
+        self.branchnum = patternlist[0].size
+
+        #勝ち目のある手がなかったら何もしない
+        if(self.branchnum == 0):
+            self.winner = not self.myturn   #相手の勝ち
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        if((self.board.toList() == np.full((4,4), None)).all()):
+            patternlist = (np.array([0, 1, 2, 3, 3, 2, 1, 0]), np.array([0, 1, 2, 3, 0, 1, 2, 3]))
+            self.branchnum = patternlist[0].size
+        
+        #ブランチの生成
+        self.branchList = []
+        for left, top in zip(patternlist[0], patternlist[1]):
+            tboard = self.board.clone()
+            tboard.setBoard(left, top, self.piece)
+            bi = MonteBranchInfo(
+                tboard,                 #現状のボードのクローンを渡す
+                self.box.clone(),       #次の想定の残り駒を渡す
+                None,                   #putでは次の想定のピースは無い
+                self.myturn,            #私の手版
+                self.param,             #パラメータ
+                self
+            )
+            bi.left = left              #left座標
+            bi.top = top                #top座標
+            self.branchList.append(bi)
+        
+        if(cgtflag):
+            #putの完全ゲーム木探索
+            self.createPutCgt()
+
+        else:
+            #プレイアウトのための初期化
+            self.playoutinit()
+    
+    def createPutCgt(self):
+        """
+        完全ゲーム木探索処理（put）
+        """
+        #枝の成長と勝敗の判定
+        for bi in self.branchList:
+            #先のchoice枝生成
+            bi.createChoiceBranch(True)
+            
+            #枝先を残すとメモリを食うため、メモリ開放
+            bi.branchList = None    #debug
+
+            if(self.isLeaf):break
+
+
+    def playoutinit(self):
+        #ucb1値を出すためのplayoutカウントをリセット
+        self.branchPlayoutCount = np.zeros((self.branchnum))
+        self.branchPlayoutWin = np.zeros((self.branchnum))
+        self.branchPlayoutDraw = np.zeros((self.branchnum))
+        self.branchPlayoutTotal = 0
+        self.branchPlayoutTarget = 0    #始めはucb1値はどれも同じため、0番目から実施。あとtotalが0だとlog関数でエラーでる。
+        self.branchlostcounter = 0
+
+    def onLeaf(self):
+        #葉の数カウント
+        self.parent.leafcounter += 1
+
+        if(self.parent.myturn == self.winner):
+            #親が勝てる手ならこのブランチも勝利手に昇格する。
+            self.parent.winner = self.winner
+            self.parent.isLeaf = True
+            self.parent.onLeaf()
+            return
+
+        if((not self.parent.myturn) == self.winner):
+            #親が負ける手なら負けカウンターを増やす。
+            self.parent.branchlostcounter += 1
+            if(self.parent.branchlostcounter == self.parent.branchnum):
+                #負けカウンターとブランチの数が同じ＝すべてのブランチが負けならば
+                self.parent.winner = self.winner
+                self.parent.isLeaf = True
+                self.parent.onLeaf()
+                return
+
+        if(self.parent.leafcounter == self.parent.branchnum):
+            #枝がすべて葉になったら。引き分け判定用
+            self.parent.isLeaf = True
+            self.parent.onLeaf()
+            return
+
+
+    def playout(self):
+        result = False
+
+        #葉の場合、その判定を返す。
+        if(self.isLeaf):
+            result = self.winner
+
+        #ブランチが無い場合、自分のパラメータでプレイアウトした結果を返す。
+        elif(self.branchList is None): 
+            result = MonteBranchRand(self.board.clone(), self.box.clone(), self.piece, self.myturn).run()
+        
+        #枝の場合。ブランチがある場合、さらにその配下のplayoutを実行し、その結果を返す。
+        else:
+            #各カウントアップ
+            self.branchPlayoutCount[self.branchPlayoutTarget] += 1          #そのブランチのプレイアウト数加算
+            self.branchPlayoutTotal += 1                                    #全体のプレイアウト数加算
+
+            #配列への参照回数を減らすため変数に格納
+            targetbi = self.branchList[self.branchPlayoutTarget]
+            
+            #枝のプレイアウトカウントが閾値を超えたらさらに枝を伸ばす。
+            #重複して生成しないようにNoneチェック
+            if(self.branchPlayoutCount[self.branchPlayoutTarget] == self.param.playoutDepthBorder and targetbi.branchList is None):
+                if(targetbi.piece is None):
+                    #choiceの場合、choiceの枝を生成
+                    cgtflag = len(np.where(targetbi.board.onboard != None)[0]) >= self.param.choiceCgt
+                    targetbi.createChoiceBranch(cgtflag)
+
+                else:
+                    #putの場合、putの枝を生成
+                    cgtflag = len(np.where(targetbi.board.onboard != None)[0]) >= self.param.putCgt
+                    targetbi.createPutBranch(cgtflag)
+
+            #枝先のプレイアウトを実行。結果は戻り値にする。
+            result = targetbi.playout()
+
+            #そのブランチの勝利数を加算
+            if result == self.myturn:
+                self.branchPlayoutWin[self.branchPlayoutTarget] += 1  #（敵のターンの時は敵の勝率を見るため自分のターンと一致しているかで判定）
+            elif result == None:
+                self.branchPlayoutDraw[self.branchPlayoutTarget] += 1   #引き分けカウント
+            
+            #ucb1値を算出し、次に調査すべきインデックスを取得
+            if(np.sum(self.branchPlayoutWin) != 0): #勝率が少しでもあるならそれを使う。
+                u = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutWin, self.branchPlayoutTotal, self.param.ucb1_c, self.param.ucb1_fpu)
+            else: #勝率0パーセントなら引き分けのucb1値を使う。
+                u = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutDraw, self.branchPlayoutTotal, self.param.ucb1_c, self.param.ucb1_fpu)
+
+            #次の周回でターゲットにするインデックスを取得
+            self.branchPlayoutTarget = u.argmax()
+
+        return result
+    
+    def searchRoute(self):
+        """
+        最善手を探してそのインデックスを返す
+        """
+        #自身が枝の場合、プレイアウト実行
+        if(not self.isLeaf):
+            endtime = time.time() + self.param.playoutTimelimit
+            while(time.time() < endtime):
+                self.playout()
+                if(self.isLeaf):break
+        
+        #戻り値インデックス 未入力状態 -1
+        returnIndex = -1
+        countmax = -1
+        
+        for i in range(self.branchnum):
+            if self.branchList[i].winner == True:
+                #勝ち確定のインデックスを返す。
+                returnIndex = i
+                break
+
+            elif self.branchList[i].winner is None:
+                #もっともプレイアウト回数の多い引き分けがあれば格納。（勝ちパターンがあるかもなのでbreakはしないで探索続行）
+                if self.isLeaf:
+                    returnIndex = i
+                elif countmax < self.branchPlayoutCount[i]:
+                    countmax = self.branchPlayoutCount[i]
+                    returnIndex = i
+        
+        #勝利、引き分け手が無いとき、プレイアウトの結果から最有力候補を取得
+        if(returnIndex == -1):
+            if self.isLeaf:
+                returnIndex = 0
+            else:
+                returnIndex = self.branchPlayoutCount.argmax()
+
+        #情報の印字
+        #util.p.print('depth\tplayer\tphase\tpattern\tisLeaf\twinner\ttotal\tcount\twin\tdraw\twinpre\tdrawper\twinucb\tdrawucb')
+        #self.myprint(0)
+        self.simpleLog()
+        
+        return returnIndex
+
+    def myprint(self, depth):
+        """
+        情報の印字処理
+        """
+        if self.branchList is None: return
+        if depth > 1 : return   #debug
+
+        #プレイアウト時の記録
+        count = None
+        if(self.branchPlayoutCount is not None):
+            count = self.branchPlayoutCount
+            win = self.branchPlayoutWin
+            draw = self.branchPlayoutDraw
+            wper = self.branchPlayoutWin/self.branchPlayoutCount
+            dper = self.branchPlayoutDraw/self.branchPlayoutCount
+            wucb = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutWin, self.branchPlayoutTotal)
+            ducb = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutDraw, self.branchPlayoutTotal)
+        
+        for i in range(self.branchnum):
+            bi = self.branchList[i]
+            c  = None if count is None else count[i]
+            w  = None if count is None else win[i]
+            d  = None if count is None else draw[i]
+            wp = None if count is None else wper[i]
+            dp = None if count is None else dper[i]
+            wu = None if count is None else wucb[i]
+            du = None if count is None else ducb[i]
+
+            val = str(depth)+'\t'+str(self.myturn)
+            if(bi.piece is not None):
+                val += '\tchoice\t'+str(bi.piece.toNumList())
+            else:
+                val += '\tput\t'+str(bi.left)+','+str(bi.top)
+            val += '\t'+str(bi.isLeaf)
+            val += '\t'+str(bi.winner)
+            val += '\t'+str(self.branchPlayoutTotal)
+            val += '\t'+str(c)
+            val += '\t'+str(w)
+            val += '\t'+str(d)
+            val += '\t'+str(wp)
+            val += '\t'+str(dp)
+            val += '\t'+str(wu)
+            val += '\t'+str(du)            
+            util.p.print(val)
+            bi.myprint(depth+1)
+        
+    def simpleLog(self):
+        util.p.print(str(self.isLeaf)+' '+str(self.winner)+' '+str(self.branchPlayoutTotal))

--- a/ktuarto/AI/montecarlo_choose_places_other_than_diagonal_lines_first.py
+++ b/ktuarto/AI/montecarlo_choose_places_other_than_diagonal_lines_first.py
@@ -1,0 +1,547 @@
+from . import base_ai
+from ..utils import ucb1, board, box, piece, util
+
+import numpy as np
+import time
+
+class Parameter:
+    def __init__(self):
+        self.playoutTimelimit = 1   #プレイアウトの時間制限
+        self.ucb1_c = 1.0           #ucb1のc定数
+        self.ucb1_fpu = 100         #fpu値
+        self.playoutDepthBorder = 4 #プレイアウトをさらに深くする閾値   -1はチェックしない
+        self.putCgt = 10
+        self.choiceCgt = 11
+        #self.putCgt = 0
+        #self.choiceCgt = 0
+
+class MontecarloChoosePlacesOtherThanGiagonalLinesFirst(base_ai.BaseAi):
+    """
+    ゲーム木を生成するクラス
+    内容は適当な値を返す処理を記述
+    callだけは判定する
+    """
+    def __init__(self):
+        self.param = Parameter()
+        
+    def choice(self, in_board, in_box):
+        """
+        in_boxリストにある最初の１つを返す
+        """
+        in_board = board.HiTechBoard(in_board)    #List, Dict形式のデータをBoardクラスに変換
+        in_box = box.Box(in_box)            #List, Dict形式のデータをBoxクラスに変換
+
+        
+        if len(in_box.piecelist) == 16 :
+            #負荷軽減のため、最初の一手はランダムで返す。（どれ選んでも同じでしょ、思考させるだけ無駄）
+            randnum = np.random.randint( len(in_box.piecelist) )
+            res_piece = in_box.piecelist[randnum]
+
+        else:
+            #モンテカルロロジック実行
+            branchinfo = MonteBranchInfo(in_board, in_box, None, True, self.param)
+            res_piece = branchinfo.runChoice()
+        
+        res_piece = res_piece.toDict()
+            
+        #callの判定
+        res_call = "Quarto" if in_board.isQuarto() else "Non"
+
+        return {\
+            'piece':res_piece,\
+            'call':res_call,\
+        }
+    
+    def put(self, in_board, in_piece):
+        """
+        in_boardからまだピースが置かれていない座標を返す
+        """
+        in_board = board.HiTechBoard(in_board)          #List, Dict形式のデータをBoardクラスに変換
+        in_piece = piece.Piece.getInstance(in_piece)    #Dict形式のデータをBoardクラスに変換
+        
+        #Boxを生成
+        in_box = box.Box(board=in_board)
+        in_box.remove(in_piece)
+
+        #モンテカルロ木探索を行う。
+        branchinfo = MonteBranchInfo(in_board, in_box, in_piece, True, self.param)
+        res_left, res_top = branchinfo.runPut()
+        
+        #置いたときのクアルト判定
+        in_board.setBoard(res_left, res_top, in_piece)
+        res_call = "Quarto" if in_board.isQuarto() else "Non"
+
+        return {\
+            'call':res_call,\
+            'left':res_left,\
+            'top':res_top,\
+        }
+
+class MonteBranchRand:
+    """
+    モンテカルロ法の乱数処理部分
+    """
+    def __init__(self, board, box, piece, myturn):
+        self.board = board
+        self.box = box
+        self.piece = piece
+        self.myturn = myturn
+        self.winner = None
+    
+    def run(self):
+        while(self.winner is None):
+            #駒がなければchoice
+            if (self.piece is None):
+                #choice前、boxが空ならゲーム終了なのでループを出る。
+                if(len(self.box.piecelist)==0):
+                    break
+
+                self.choiceRand()
+                self.myturn = not self.myturn #choiceの後プレイヤーを交代
+
+            #駒があればput
+            else:
+                self.putRand()
+
+                #put後、boxが空ならゲーム終了なのでループを出る。
+                if(len(self.box.piecelist)==0):
+                    break
+        
+        #勝者を返す
+        return self.winner
+    
+    def putRand(self):
+        #このputで勝てる場合、自分が勝って終了
+        if(util.endPiece(self.board, self.piece)):
+            self.winner = self.myturn
+            return
+        
+        checkpattern = util.losePiecePos2(self.board,self.box,self.piece)
+
+        #選択肢が残っていなければ負けを返す
+        if ( not np.any(checkpattern) ):
+            self.winner = not self.myturn
+            return
+
+        patternlist = np.where(checkpattern)
+        
+        #乱数生成
+        randnum = np.random.randint(patternlist[0].size)
+
+        #手を進める
+        self.board.setBoard(patternlist[0][randnum], patternlist[1][randnum], self.piece)
+        
+        #選んだ駒を空にする
+        self.piece = None
+
+    def choiceRand(self):
+        #勝ち目のあるピースを取得
+        oddspieces = util.oddsPieces(self.board, self.box.piecelist)
+
+        #どれを選んでも負ける場合
+        patternsize = len(oddspieces)
+        if (patternsize == 0):
+            self.winner = not self.myturn   #相手の勝ち
+            return
+
+        #乱数生成
+        randnum = np.random.randint( patternsize )
+
+        #駒を選択
+        self.piece = oddspieces[randnum]
+
+        #boxから駒をはずす。
+        self.box.remove(self.piece)
+
+class DammyBranch:
+    """
+    MonteBranchRandのonLeafメソッドを仮で行うためのクラス
+    if(self.parent is not None)で毎回チェックをなくすための処置
+    """
+    def __init__(self):
+        self.myturn = True
+        self.winner = False
+        self.isLeaf = False
+        self.branchlostcounter = 0
+        self.leafcounter = 0
+        self.branchnum = 1
+    
+    def onLeaf(self):
+        pass
+
+class MonteBranchInfo:
+    
+    def __init__(self, board, box, piece, myturn, param, parent=DammyBranch()):
+        self.board = board              #ボード
+        self.box = box                  #ボックス
+        self.piece = piece              #駒
+        self.myturn = myturn            #ターン（trueが自分）
+        self.param = param              #プレイアウト試行回数
+
+        self.branchList = None          #ブランチリスト
+        self.left = None                #putのleft座標
+        self.top = None                 #putのtop座標
+        
+        self.branchnum = 0              #ブランチの数
+        self.branchPlayoutCount = None  #ブランチプレイアウト数（numpy配列）
+        self.branchPlayoutWin = None    #ブランチプレイアウト勝利数（numpy配列）
+        self.branchPlayoutDraw = None   #ブランチプレイアウト引分数（numpy配列）
+        self.branchPlayoutTotal = 0     #ブランチプレイアウトの合計（数値）
+
+        self.branchPlayoutTarget = 0    #ブランチプレイアウトを行う対象
+        self.branchlostcounter = 0      #負けブランチの数をカウントする
+        self.leafcounter = 0            #枝が葉になった数をカウントする
+
+        self.isLeaf = False             #ゲーム葉フラグ。ゲームの決着がついたフラグ。gameoverとほぼ同義
+        self.winner = None              #ゲームの勝者
+        self.parent = parent            #親ブランチ
+
+    def runChoice(self):
+        #ブランチ生成
+        cgtflag = len(np.where(self.board.onboard != None)[0]) >= self.param.choiceCgt
+        self.createChoiceBranch(cgtflag)
+
+        #勝てる手がなければ（ブランチがなければ）先頭を返す。
+        if( self.branchList is None ):return self.box.piecelist[0]
+        
+        #ルート探査
+        topScoreIndex = self.searchRoute()
+        return self.branchList[topScoreIndex].piece
+    
+    def runPut(self):
+        #このputで勝てる場合、勝てる手を選んで終了
+        if(util.endPiece(self.board, self.piece)):
+            return util.endPiecePos(self.board, self.piece)  #戻り値はleft, topの二つ
+        
+        #ブランチの生成
+        cgtflag = len(np.where(self.board.onboard != None)[0]) >= self.param.putCgt
+        self.createPutBranch(cgtflag)
+
+        #勝てる手がなければ（ブランチがなければ）先頭を返す。
+        if( self.branchList is None ):
+            index = np.where(self.board.onboard == None)
+            return index[0][0], index[1][0]
+
+        #ルート探査
+        topScoreIndex = self.searchRoute()
+        return self.branchList[topScoreIndex].left, self.branchList[topScoreIndex].top
+
+    def createChoiceBranch(self, cgtflag):
+        """
+        ゲーム木生成処理（choice）
+        cgtflag：Trueのとき完全ゲーム木を生成する。
+        """
+        #駒が無ければ終了
+        if(len(self.box.piecelist)==0):
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        #勝ち目の無い選択を減らす
+        oddspieces = util.oddsPieces(self.board, self.box.piecelist)
+
+        #ブランチの数を設定
+        self.branchnum = len(oddspieces)
+
+        #手がなかったら何もしない
+        if(self.branchnum == 0):
+            self.winner = not self.myturn   #相手の勝ち
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        self.branchList = []
+        for p in oddspieces:
+            tbox = self.box.clone()
+            tbox.remove(p)
+            bi = MonteBranchInfo(
+                self.board.clone(),     #現状のボードのクローンを渡す
+                tbox,                   #次の想定の残り駒を渡す
+                p,                      #次の想定のピースを渡す
+                not self.myturn,        #相手プレイヤーの手版になる
+                self.param,             #パラメータ
+                self
+            )
+            self.branchList.append(bi)
+        
+        if(cgtflag):
+            #choiceの完全ゲーム木探索
+            self.createChoiceCgt()
+
+        else:
+            #プレイアウトのための初期化
+            self.playoutinit()
+    
+    def createChoiceCgt(self):
+        """
+        完全ゲーム木探索処理（choice）
+        """
+        #枝の成長と勝敗の判定
+        for bi in self.branchList:
+            
+            #先のput枝生成
+            bi.createPutBranch(True)
+            bi.branchList = None    #debug
+            
+            #ブランチを生成し、それがisLeafとなるとonLeafメソッドが実行される。
+            #それをチェックして葉になっていたら終了
+            if(self.isLeaf): break
+
+
+    def createPutBranch(self, cgtflag):
+        """
+        ゲーム木生成処理（put）
+        cgtflag：Trueのとき完全ゲーム木を生成する。
+        """
+        #このputで勝てる場合、自分が勝って終了
+        if(util.endPiece(self.board, self.piece)):
+            self.winner = self.myturn
+            self.isLeaf = True
+            self.onLeaf()
+            return
+        
+        #駒が無ければ終了
+        if(len(self.box.piecelist)==0):
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        #勝ち目のある駒のない箇所のインデックス一覧を取得
+        checkpattern = util.losePiecePos2(self.board,self.box,self.piece)
+        patternlist = np.where(checkpattern)
+        
+        #ブランチの数を設定
+        self.branchnum = patternlist[0].size
+
+        #勝ち目のある手がなかったら何もしない
+        if(self.branchnum == 0):
+            self.winner = not self.myturn   #相手の勝ち
+            self.isLeaf = True
+            self.onLeaf()
+            return
+
+        if((self.board.toList() == np.full((4,4), None)).all()):
+            patternlist = (np.array([1, 2, 0, 3, 0, 3, 1, 2]), np.array([0, 0, 1, 1, 2, 2, 3, 3]))
+            self.branchnum = patternlist[0].size
+        
+        #ブランチの生成
+        self.branchList = []
+        for left, top in zip(patternlist[0], patternlist[1]):
+            tboard = self.board.clone()
+            tboard.setBoard(left, top, self.piece)
+            bi = MonteBranchInfo(
+                tboard,                 #現状のボードのクローンを渡す
+                self.box.clone(),       #次の想定の残り駒を渡す
+                None,                   #putでは次の想定のピースは無い
+                self.myturn,            #私の手版
+                self.param,             #パラメータ
+                self
+            )
+            bi.left = left              #left座標
+            bi.top = top                #top座標
+            self.branchList.append(bi)
+        
+        if(cgtflag):
+            #putの完全ゲーム木探索
+            self.createPutCgt()
+
+        else:
+            #プレイアウトのための初期化
+            self.playoutinit()
+    
+    def createPutCgt(self):
+        """
+        完全ゲーム木探索処理（put）
+        """
+        #枝の成長と勝敗の判定
+        for bi in self.branchList:
+            #先のchoice枝生成
+            bi.createChoiceBranch(True)
+            
+            #枝先を残すとメモリを食うため、メモリ開放
+            bi.branchList = None    #debug
+
+            if(self.isLeaf):break
+
+
+    def playoutinit(self):
+        #ucb1値を出すためのplayoutカウントをリセット
+        self.branchPlayoutCount = np.zeros((self.branchnum))
+        self.branchPlayoutWin = np.zeros((self.branchnum))
+        self.branchPlayoutDraw = np.zeros((self.branchnum))
+        self.branchPlayoutTotal = 0
+        self.branchPlayoutTarget = 0    #始めはucb1値はどれも同じため、0番目から実施。あとtotalが0だとlog関数でエラーでる。
+        self.branchlostcounter = 0
+
+    def onLeaf(self):
+        #葉の数カウント
+        self.parent.leafcounter += 1
+
+        if(self.parent.myturn == self.winner):
+            #親が勝てる手ならこのブランチも勝利手に昇格する。
+            self.parent.winner = self.winner
+            self.parent.isLeaf = True
+            self.parent.onLeaf()
+            return
+
+        if((not self.parent.myturn) == self.winner):
+            #親が負ける手なら負けカウンターを増やす。
+            self.parent.branchlostcounter += 1
+            if(self.parent.branchlostcounter == self.parent.branchnum):
+                #負けカウンターとブランチの数が同じ＝すべてのブランチが負けならば
+                self.parent.winner = self.winner
+                self.parent.isLeaf = True
+                self.parent.onLeaf()
+                return
+
+        if(self.parent.leafcounter == self.parent.branchnum):
+            #枝がすべて葉になったら。引き分け判定用
+            self.parent.isLeaf = True
+            self.parent.onLeaf()
+            return
+
+
+    def playout(self):
+        result = False
+
+        #葉の場合、その判定を返す。
+        if(self.isLeaf):
+            result = self.winner
+
+        #ブランチが無い場合、自分のパラメータでプレイアウトした結果を返す。
+        elif(self.branchList is None): 
+            result = MonteBranchRand(self.board.clone(), self.box.clone(), self.piece, self.myturn).run()
+        
+        #枝の場合。ブランチがある場合、さらにその配下のplayoutを実行し、その結果を返す。
+        else:
+            #各カウントアップ
+            self.branchPlayoutCount[self.branchPlayoutTarget] += 1          #そのブランチのプレイアウト数加算
+            self.branchPlayoutTotal += 1                                    #全体のプレイアウト数加算
+
+            #配列への参照回数を減らすため変数に格納
+            targetbi = self.branchList[self.branchPlayoutTarget]
+            
+            #枝のプレイアウトカウントが閾値を超えたらさらに枝を伸ばす。
+            #重複して生成しないようにNoneチェック
+            if(self.branchPlayoutCount[self.branchPlayoutTarget] == self.param.playoutDepthBorder and targetbi.branchList is None):
+                if(targetbi.piece is None):
+                    #choiceの場合、choiceの枝を生成
+                    cgtflag = len(np.where(targetbi.board.onboard != None)[0]) >= self.param.choiceCgt
+                    targetbi.createChoiceBranch(cgtflag)
+
+                else:
+                    #putの場合、putの枝を生成
+                    cgtflag = len(np.where(targetbi.board.onboard != None)[0]) >= self.param.putCgt
+                    targetbi.createPutBranch(cgtflag)
+
+            #枝先のプレイアウトを実行。結果は戻り値にする。
+            result = targetbi.playout()
+
+            #そのブランチの勝利数を加算
+            if result == self.myturn:
+                self.branchPlayoutWin[self.branchPlayoutTarget] += 1  #（敵のターンの時は敵の勝率を見るため自分のターンと一致しているかで判定）
+            elif result == None:
+                self.branchPlayoutDraw[self.branchPlayoutTarget] += 1   #引き分けカウント
+            
+            #ucb1値を算出し、次に調査すべきインデックスを取得
+            if(np.sum(self.branchPlayoutWin) != 0): #勝率が少しでもあるならそれを使う。
+                u = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutWin, self.branchPlayoutTotal, self.param.ucb1_c, self.param.ucb1_fpu)
+            else: #勝率0パーセントなら引き分けのucb1値を使う。
+                u = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutDraw, self.branchPlayoutTotal, self.param.ucb1_c, self.param.ucb1_fpu)
+
+            #次の周回でターゲットにするインデックスを取得
+            self.branchPlayoutTarget = u.argmax()
+
+        return result
+    
+    def searchRoute(self):
+        """
+        最善手を探してそのインデックスを返す
+        """
+        #自身が枝の場合、プレイアウト実行
+        if(not self.isLeaf):
+            endtime = time.time() + self.param.playoutTimelimit
+            while(time.time() < endtime):
+                self.playout()
+                if(self.isLeaf):break
+        
+        #戻り値インデックス 未入力状態 -1
+        returnIndex = -1
+        countmax = -1
+        
+        for i in range(self.branchnum):
+            if self.branchList[i].winner == True:
+                #勝ち確定のインデックスを返す。
+                returnIndex = i
+                break
+
+            elif self.branchList[i].winner is None:
+                #もっともプレイアウト回数の多い引き分けがあれば格納。（勝ちパターンがあるかもなのでbreakはしないで探索続行）
+                if self.isLeaf:
+                    returnIndex = i
+                elif countmax < self.branchPlayoutCount[i]:
+                    countmax = self.branchPlayoutCount[i]
+                    returnIndex = i
+        
+        #勝利、引き分け手が無いとき、プレイアウトの結果から最有力候補を取得
+        if(returnIndex == -1):
+            if self.isLeaf:
+                returnIndex = 0
+            else:
+                returnIndex = self.branchPlayoutCount.argmax()
+
+        #情報の印字
+        #util.p.print('depth\tplayer\tphase\tpattern\tisLeaf\twinner\ttotal\tcount\twin\tdraw\twinpre\tdrawper\twinucb\tdrawucb')
+        #self.myprint(0)
+        self.simpleLog()
+        
+        return returnIndex
+
+    def myprint(self, depth):
+        """
+        情報の印字処理
+        """
+        if self.branchList is None: return
+        if depth > 1 : return   #debug
+
+        #プレイアウト時の記録
+        count = None
+        if(self.branchPlayoutCount is not None):
+            count = self.branchPlayoutCount
+            win = self.branchPlayoutWin
+            draw = self.branchPlayoutDraw
+            wper = self.branchPlayoutWin/self.branchPlayoutCount
+            dper = self.branchPlayoutDraw/self.branchPlayoutCount
+            wucb = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutWin, self.branchPlayoutTotal)
+            ducb = ucb1.UCB1.ucb1(self.branchPlayoutCount, self.branchPlayoutDraw, self.branchPlayoutTotal)
+        
+        for i in range(self.branchnum):
+            bi = self.branchList[i]
+            c  = None if count is None else count[i]
+            w  = None if count is None else win[i]
+            d  = None if count is None else draw[i]
+            wp = None if count is None else wper[i]
+            dp = None if count is None else dper[i]
+            wu = None if count is None else wucb[i]
+            du = None if count is None else ducb[i]
+
+            val = str(depth)+'\t'+str(self.myturn)
+            if(bi.piece is not None):
+                val += '\tchoice\t'+str(bi.piece.toNumList())
+            else:
+                val += '\tput\t'+str(bi.left)+','+str(bi.top)
+            val += '\t'+str(bi.isLeaf)
+            val += '\t'+str(bi.winner)
+            val += '\t'+str(self.branchPlayoutTotal)
+            val += '\t'+str(c)
+            val += '\t'+str(w)
+            val += '\t'+str(d)
+            val += '\t'+str(wp)
+            val += '\t'+str(dp)
+            val += '\t'+str(wu)
+            val += '\t'+str(du)            
+            util.p.print(val)
+            bi.myprint(depth+1)
+        
+    def simpleLog(self):
+        util.p.print(str(self.isLeaf)+' '+str(self.winner)+' '+str(self.branchPlayoutTotal))

--- a/ktuarto/scripts/run.py
+++ b/ktuarto/scripts/run.py
@@ -11,6 +11,8 @@ from ..utils import gamemain, util
 from ..AI.sample_ai import SampleAi
 from ..AI.random_ai import RandomAi, RandomAi2, RandomAi3
 from ..AI.montecarlo_ai import Montecarlo
+from ..AI.montecarlo_choose_diagonal_lines_first import MontecarloChooseDiagonalLinesFirst
+from ..AI.montecarlo_choose_places_other_than_diagonal_lines_first import MontecarloChoosePlacesOtherThanGiagonalLinesFirst
 
 import click
 import sys

--- a/ktuarto/utils/gamemain.py
+++ b/ktuarto/utils/gamemain.py
@@ -2,6 +2,8 @@ from . import board, box, piece, gameplayer, gameplayerinfo, util, rating
 
 import numpy as np
 import time
+import firebase_admin
+from firebase_admin import credentials
 
 class GameMain:
     """
@@ -181,6 +183,11 @@ def winningPercentageRun(gamenum, p0=None, p1=None):
     }
     scoreper = {}
     elo = {player0: 0, player1: 0}
+
+    cred = credentials.ApplicationDefault()
+    firebase_admin.initialize_app(cred, {
+      'projectId': 'quartobattlestation'
+    })
 
     for i in range(gamenum):
         #ゲーム実行

--- a/ktuarto/utils/rating.py
+++ b/ktuarto/utils/rating.py
@@ -2,8 +2,6 @@
 
 import os
 import json
-import firebase_admin
-from firebase_admin import credentials
 from firebase_admin import firestore
 from dotenv import load_dotenv
 
@@ -43,10 +41,6 @@ def calcEloRating (PlayerAName, PlayerBName, winNumberPlayerA, winNumberPlayerB,
     return (newEloPlayerA,newEloPlayerB)
 
 def getFirestoreClient():
-    cred = credentials.ApplicationDefault()
-    firebase_admin.initialize_app(cred, {
-      'projectId': 'quartobattlestation'
-    })
     return firestore.client()
 
 def getElo(client, name):

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,30 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "cachecontrol"
+version = "0.12.10"
+description = "httplib2 caching for requests"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+msgpack = ">=0.5.2"
+requests = "*"
+
+[package.extras]
+filecache = ["lockfile (>=0.9)"]
+redis = ["redis (>=2.10.5)"]
+
+[[package]]
+name = "cachetools"
+version = "4.2.4"
+description = "Extensible memoizing collections and decorators"
+category = "main"
+optional = false
+python-versions = "~=3.5"
+
+[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -59,6 +83,213 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "firebase-admin"
+version = "5.2.0"
+description = "Firebase Admin Python SDK"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cachecontrol = ">=0.12.6"
+google-api-core = {version = ">=1.22.1,<3.0.0dev", extras = ["grpc"], markers = "platform_python_implementation != \"PyPy\""}
+google-api-python-client = ">=1.7.8"
+google-cloud-firestore = {version = ">=2.1.0", markers = "platform_python_implementation != \"PyPy\""}
+google-cloud-storage = ">=1.37.1"
+
+[[package]]
+name = "google-api-core"
+version = "2.3.2"
+description = "Google API client core library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+google-auth = ">=1.25.0,<3.0dev"
+googleapis-common-protos = ">=1.52.0,<2.0dev"
+grpcio = {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""}
+grpcio-status = {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""}
+protobuf = ">=3.12.0"
+requests = ">=2.18.0,<3.0.0dev"
+
+[package.extras]
+grpc = ["grpcio (>=1.33.2,<2.0dev)", "grpcio-status (>=1.33.2,<2.0dev)"]
+grpcgcp = ["grpcio-gcp (>=0.2.2)"]
+grpcio-gcp = ["grpcio-gcp (>=0.2.2)"]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.33.0"
+description = "Google API Client Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+google-api-core = ">=1.21.0,<3.0.0dev"
+google-auth = ">=1.16.0,<3.0.0dev"
+google-auth-httplib2 = ">=0.1.0"
+httplib2 = ">=0.15.0,<1dev"
+uritemplate = ">=3.0.0,<5"
+
+[[package]]
+name = "google-auth"
+version = "2.3.3"
+description = "Google Authentication Library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+
+[package.dependencies]
+cachetools = ">=2.0.0,<5.0"
+pyasn1-modules = ">=0.2.1"
+rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
+six = ">=1.9.0"
+
+[package.extras]
+aiohttp = ["requests (>=2.20.0,<3.0.0dev)", "aiohttp (>=3.6.2,<4.0.0dev)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.1.0"
+description = "Google Authentication Library: httplib2 transport"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+google-auth = "*"
+httplib2 = ">=0.15.0"
+six = "*"
+
+[[package]]
+name = "google-cloud-core"
+version = "2.2.1"
+description = "Google Cloud API client core library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+google-api-core = ">=1.21.0,<3.0.0dev"
+google-auth = ">=1.24.0,<3.0dev"
+
+[package.extras]
+grpc = ["grpcio (>=1.8.2,<2.0dev)"]
+
+[[package]]
+name = "google-cloud-firestore"
+version = "2.3.4"
+description = "Google Cloud Firestore API client library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+google-api-core = {version = ">=1.26.0,<3.0.0dev", extras = ["grpc"]}
+google-cloud-core = ">=1.4.1,<3.0.0dev"
+packaging = ">=14.3"
+proto-plus = ">=1.10.0"
+
+[[package]]
+name = "google-cloud-storage"
+version = "1.43.0"
+description = "Google Cloud Storage API client library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+
+[package.dependencies]
+google-api-core = {version = ">=1.29.0,<3.0dev", markers = "python_version >= \"3.6\""}
+google-auth = {version = ">=1.25.0,<3.0dev", markers = "python_version >= \"3.6\""}
+google-cloud-core = {version = ">=1.6.0,<3.0dev", markers = "python_version >= \"3.6\""}
+google-resumable-media = {version = ">=1.3.0,<3.0dev", markers = "python_version >= \"3.6\""}
+protobuf = {version = "*", markers = "python_version >= \"3.6\""}
+requests = ">=2.18.0,<3.0.0dev"
+six = "*"
+
+[[package]]
+name = "google-crc32c"
+version = "1.3.0"
+description = "A python wrapper of the C library 'Google CRC32C'"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+testing = ["pytest"]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.1.0"
+description = "Utilities for Google Media Downloads and Resumable Uploads"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+google-crc32c = ">=1.0,<2.0dev"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)"]
+requests = ["requests (>=2.18.0,<3.0.0dev)"]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.54.0"
+description = "Common protobufs used in Google APIs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+protobuf = ">=3.12.0"
+
+[package.extras]
+grpc = ["grpcio (>=1.0.0)"]
+
+[[package]]
+name = "grpcio"
+version = "1.43.0"
+description = "HTTP/2-based RPC framework"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+six = ">=1.5.2"
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.43.0)"]
+
+[[package]]
+name = "grpcio-status"
+version = "1.43.0"
+description = "Status proto mapping for gRPC"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+googleapis-common-protos = ">=1.5.5"
+grpcio = ">=1.43.0"
+protobuf = ">=3.6.0"
+
+[[package]]
+name = "httplib2"
+version = "0.20.2"
+description = "A comprehensive HTTP client library."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0.2,<3.0.3 || >3.0.3,<4", markers = "python_version > \"3.0\""}
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -75,6 +306,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "msgpack"
+version = "1.0.3"
+description = "MessagePack (de)serializer."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "numpy"
 version = "1.21.2"
 description = "NumPy is the fundamental package for array computing with Python."
@@ -86,7 +325,7 @@ python-versions = ">=3.7,<3.11"
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -105,6 +344,28 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 dev = ["pre-commit", "tox"]
 
 [[package]]
+name = "proto-plus"
+version = "1.19.8"
+description = "Beautiful, Pythonic protocol buffers."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+protobuf = ">=3.19.0"
+
+[package.extras]
+testing = ["google-api-core[grpc] (>=1.22.2)"]
+
+[[package]]
+name = "protobuf"
+version = "3.19.1"
+description = "Protocol Buffers"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -113,10 +374,29 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pyasn1"
+version = "0.4.8"
+description = "ASN.1 types and codecs"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.2.8"
+description = "A collection of ASN.1-based protocols modules."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyasn1 = ">=0.4.6,<0.5.0"
+
+[[package]]
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -172,6 +452,33 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "rsa"
+version = "4.8"
+description = "Pure-Python RSA implementation"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4"
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "uritemplate"
+version = "4.1.1"
+description = "Implementation of RFC 6570 URI Templates"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
 version = "1.26.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -195,7 +502,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.11"
-content-hash = "e8d72982236d0d24967e6ad50f9bbec3b7763edebad10c935c32b3fcfac87f8d"
+content-hash = "970900ef8cea753a98ebd53051a7dd1c0972be26f81f35e8b7177c94a68fc34a"
 
 [metadata.files]
 atomicwrites = [
@@ -205,6 +512,14 @@ atomicwrites = [
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
+cachecontrol = [
+    {file = "CacheControl-0.12.10-py2.py3-none-any.whl", hash = "sha256:b0d43d8f71948ef5ebdee5fe236b86c6ffc7799370453dccb0e894c20dfa487c"},
+    {file = "CacheControl-0.12.10.tar.gz", hash = "sha256:d8aca75b82eec92d84b5d6eb8c8f66ea16f09d2adb09dbca27fe2d5fc8d3732d"},
+]
+cachetools = [
+    {file = "cachetools-4.2.4-py3-none-any.whl", hash = "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"},
+    {file = "cachetools-4.2.4.tar.gz", hash = "sha256:89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -222,6 +537,145 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+firebase-admin = [
+    {file = "firebase_admin-5.2.0-py3-none-any.whl", hash = "sha256:e6d69fb055b1c1e4dc048e0192772c978f9c826a9912d566e5a924eea449bdc1"},
+    {file = "firebase_admin-5.2.0.tar.gz", hash = "sha256:cd1a47ff43e5d83cf8d6e2c478387860c363876d9b9149b5034a13b81f8b4bda"},
+]
+google-api-core = [
+    {file = "google-api-core-2.3.2.tar.gz", hash = "sha256:c8889f45cf58deca522888ae1d39b2a25e93e7d1b019ae8cee6456d5c726a40c"},
+    {file = "google_api_core-2.3.2-py2.py3-none-any.whl", hash = "sha256:3c562d393aed7e3d2011fcd1f103b490c411dcf5644b6312ca11a166a6ea8faf"},
+]
+google-api-python-client = [
+    {file = "google-api-python-client-2.33.0.tar.gz", hash = "sha256:38e98611794632a12479fafbabe0b5027e8fcfc412e8375f1b23db0bc0209181"},
+    {file = "google_api_python_client-2.33.0-py2.py3-none-any.whl", hash = "sha256:1322d026110bc62eb29a4a25a15895dac51486b30a29b5943bc456318677280b"},
+]
+google-auth = [
+    {file = "google-auth-2.3.3.tar.gz", hash = "sha256:d83570a664c10b97a1dc6f8df87e5fdfff012f48f62be131e449c20dfc32630e"},
+    {file = "google_auth-2.3.3-py2.py3-none-any.whl", hash = "sha256:a348a50b027679cb7dae98043ac8dbcc1d7951f06d8387496071a1e05a2465c0"},
+]
+google-auth-httplib2 = [
+    {file = "google-auth-httplib2-0.1.0.tar.gz", hash = "sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac"},
+    {file = "google_auth_httplib2-0.1.0-py2.py3-none-any.whl", hash = "sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10"},
+]
+google-cloud-core = [
+    {file = "google-cloud-core-2.2.1.tar.gz", hash = "sha256:476d1f71ab78089e0638e0aaf34bfdc99bab4fce8f4170ba6321a5243d13c5c7"},
+    {file = "google_cloud_core-2.2.1-py2.py3-none-any.whl", hash = "sha256:ab6cee07791afe4e210807ceeab749da6a076ab16d496ac734bf7e6ffea27486"},
+]
+google-cloud-firestore = [
+    {file = "google-cloud-firestore-2.3.4.tar.gz", hash = "sha256:714e1bc1fc51029d78aa64933bef2efc03daedc9565ea79ec91b843b052016ec"},
+    {file = "google_cloud_firestore-2.3.4-py2.py3-none-any.whl", hash = "sha256:692e2ff732ebf4d20fa5eba3686edec8f3a02a72f177813dccdfbe0770e1d1a2"},
+]
+google-cloud-storage = [
+    {file = "google-cloud-storage-1.43.0.tar.gz", hash = "sha256:f3b4f4be5c8a1b5727a8f7136c94d3bacdd4b7bf11f9553f51ae4c1d876529d3"},
+    {file = "google_cloud_storage-1.43.0-py2.py3-none-any.whl", hash = "sha256:bb3e4088054d50616bd57e4b81bb158db804c91faed39279d666e2fd07d2c118"},
+]
+google-crc32c = [
+    {file = "google-crc32c-1.3.0.tar.gz", hash = "sha256:276de6273eb074a35bc598f8efbc00c7869c5cf2e29c90748fccc8c898c244df"},
+    {file = "google_crc32c-1.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cb6994fff247987c66a8a4e550ef374671c2b82e3c0d2115e689d21e511a652d"},
+    {file = "google_crc32c-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c9da0a39b53d2fab3e5467329ed50e951eb91386e9d0d5b12daf593973c3b168"},
+    {file = "google_crc32c-1.3.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:eb0b14523758e37802f27b7f8cd973f5f3d33be7613952c0df904b68c4842f0e"},
+    {file = "google_crc32c-1.3.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:95c68a4b9b7828ba0428f8f7e3109c5d476ca44996ed9a5f8aac6269296e2d59"},
+    {file = "google_crc32c-1.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c3cf890c3c0ecfe1510a452a165431b5831e24160c5fcf2071f0f85ca5a47cd"},
+    {file = "google_crc32c-1.3.0-cp310-cp310-win32.whl", hash = "sha256:3bbce1be3687bbfebe29abdb7631b83e6b25da3f4e1856a1611eb21854b689ea"},
+    {file = "google_crc32c-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:c124b8c8779bf2d35d9b721e52d4adb41c9bfbde45e6a3f25f0820caa9aba73f"},
+    {file = "google_crc32c-1.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:42ae4781333e331a1743445931b08ebdad73e188fd554259e772556fc4937c48"},
+    {file = "google_crc32c-1.3.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ff71073ebf0e42258a42a0b34f2c09ec384977e7f6808999102eedd5b49920e3"},
+    {file = "google_crc32c-1.3.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fe31de3002e7b08eb20823b3735b97c86c5926dd0581c7710a680b418a8709d4"},
+    {file = "google_crc32c-1.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd7760a88a8d3d705ff562aa93f8445ead54f58fd482e4f9e2bafb7e177375d4"},
+    {file = "google_crc32c-1.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a0b9e622c3b2b8d0ce32f77eba617ab0d6768b82836391e4f8f9e2074582bf02"},
+    {file = "google_crc32c-1.3.0-cp36-cp36m-win32.whl", hash = "sha256:779cbf1ce375b96111db98fca913c1f5ec11b1d870e529b1dc7354b2681a8c3a"},
+    {file = "google_crc32c-1.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:04e7c220798a72fd0f08242bc8d7a05986b2a08a0573396187fd32c1dcdd58b3"},
+    {file = "google_crc32c-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e7a539b9be7b9c00f11ef16b55486141bc2cdb0c54762f84e3c6fc091917436d"},
+    {file = "google_crc32c-1.3.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ca60076c388728d3b6ac3846842474f4250c91efbfe5afa872d3ffd69dd4b318"},
+    {file = "google_crc32c-1.3.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05340b60bf05b574159e9bd940152a47d38af3fb43803ffe71f11d704b7696a6"},
+    {file = "google_crc32c-1.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:318f73f5484b5671f0c7f5f63741ab020a599504ed81d209b5c7129ee4667407"},
+    {file = "google_crc32c-1.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:9f58099ad7affc0754ae42e6d87443299f15d739b0ce03c76f515153a5cda06c"},
+    {file = "google_crc32c-1.3.0-cp37-cp37m-win32.whl", hash = "sha256:f52a4ad2568314ee713715b1e2d79ab55fab11e8b304fd1462ff5cccf4264b3e"},
+    {file = "google_crc32c-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:bab4aebd525218bab4ee615786c4581952eadc16b1ff031813a2fd51f0cc7b08"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:dda4d8a3bb0b50f540f6ff4b6033f3a74e8bf0bd5320b70fab2c03e512a62812"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fec221a051150eeddfdfcff162e6db92c65ecf46cb0f7bb1bf812a1520ec026b"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:226f2f9b8e128a6ca6a9af9b9e8384f7b53a801907425c9a292553a3a7218ce0"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a7f9cbea4245ee36190f85fe1814e2d7b1e5f2186381b082f5d59f99b7f11328"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a4db36f9721fdf391646685ecffa404eb986cbe007a3289499020daf72e88a2"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:12674a4c3b56b706153a358eaa1018c4137a5a04635b92b4652440d3d7386206"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-win32.whl", hash = "sha256:650e2917660e696041ab3dcd7abac160b4121cd9a484c08406f24c5964099829"},
+    {file = "google_crc32c-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:58be56ae0529c664cc04a9c76e68bb92b091e0194d6e3c50bea7e0f266f73713"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:96a8918a78d5d64e07c8ea4ed2bc44354e3f93f46a4866a40e8db934e4c0d74b"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:13af315c3a0eec8bb8b8d80b8b128cb3fcd17d7e4edafc39647846345a3f003a"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6311853aa2bba4064d0c28ca54e7b50c4d48e3de04f6770f6c60ebda1e975267"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ed447680ff21c14aaceb6a9f99a5f639f583ccfe4ce1a5e1d48eb41c3d6b3217"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1c1d6236feab51200272d79b3d3e0f12cf2cbb12b208c835b175a21efdb0a73"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e0f1ff55dde0ebcfbef027edc21f71c205845585fffe30d4ec4979416613e9b3"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-win32.whl", hash = "sha256:fbd60c6aaa07c31d7754edbc2334aef50601b7f1ada67a96eb1eb57c7c72378f"},
+    {file = "google_crc32c-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:127f9cc3ac41b6a859bd9dc4321097b1a4f6aa7fdf71b4f9227b9e3ebffb4422"},
+    {file = "google_crc32c-1.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fc28e0db232c62ca0c3600884933178f0825c99be4474cdd645e378a10588125"},
+    {file = "google_crc32c-1.3.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1926fd8de0acb9d15ee757175ce7242e235482a783cd4ec711cc999fc103c24e"},
+    {file = "google_crc32c-1.3.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5da2c81575cc3ccf05d9830f9e8d3c70954819ca9a63828210498c0774fda1a3"},
+    {file = "google_crc32c-1.3.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f712ce54e0d631370e1f4997b3f182f3368179198efc30d477c75d1f44942"},
+    {file = "google_crc32c-1.3.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:7f6fe42536d9dcd3e2ffb9d3053f5d05221ae3bbcefbe472bdf2c71c793e3183"},
+]
+google-resumable-media = [
+    {file = "google-resumable-media-2.1.0.tar.gz", hash = "sha256:725b989e0dd387ef2703d1cc8e86217474217f4549593c477fd94f4024a0f911"},
+    {file = "google_resumable_media-2.1.0-py2.py3-none-any.whl", hash = "sha256:cdc75ea0361e39704dc7df7da59fbd419e73c8bc92eac94d8a020d36baa9944b"},
+]
+googleapis-common-protos = [
+    {file = "googleapis-common-protos-1.54.0.tar.gz", hash = "sha256:a4031d6ec6c2b1b6dc3e0be7e10a1bd72fb0b18b07ef9be7b51f2c1004ce2437"},
+    {file = "googleapis_common_protos-1.54.0-py2.py3-none-any.whl", hash = "sha256:e54345a2add15dc5e1a7891c27731ff347b4c33765d79b5ed7026a6c0c7cbcae"},
+]
+grpcio = [
+    {file = "grpcio-1.43.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:a4e786a8ee8b30b25d70ee52cda6d1dbba2a8ca2f1208d8e20ed8280774f15c8"},
+    {file = "grpcio-1.43.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:af9c3742f6c13575c0d4147a8454da0ff5308c4d9469462ff18402c6416942fe"},
+    {file = "grpcio-1.43.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:fdac966699707b5554b815acc272d81e619dd0999f187cd52a61aef075f870ee"},
+    {file = "grpcio-1.43.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e463b4aa0a6b31cf2e57c4abc1a1b53531a18a570baeed39d8d7b65deb16b7e"},
+    {file = "grpcio-1.43.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f11d05402e0ac3a284443d8a432d3dfc76a6bd3f7b5858cddd75617af2d7bd9b"},
+    {file = "grpcio-1.43.0-cp310-cp310-win32.whl", hash = "sha256:c36f418c925a41fccada8f7ae9a3d3e227bfa837ddbfddd3d8b0ac252d12dda9"},
+    {file = "grpcio-1.43.0-cp310-cp310-win_amd64.whl", hash = "sha256:772b943f34374744f70236bbbe0afe413ed80f9ae6303503f85e2b421d4bca92"},
+    {file = "grpcio-1.43.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:cbc9b83211d905859dcf234ad39d7193ff0f05bfc3269c364fb0d114ee71de59"},
+    {file = "grpcio-1.43.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:fb7229fa2a201a0c377ff3283174ec966da8f9fd7ffcc9a92f162d2e7fc9025b"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:17b75f220ee6923338155b4fcef4c38802b9a57bc57d112c9599a13a03e99f8d"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:6620a5b751b099b3b25553cfc03dfcd873cda06f9bb2ff7e9948ac7090e20f05"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:1898f999383baac5fcdbdef8ea5b1ef204f38dc211014eb6977ac6e55944d738"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47b6821238d8978014d23b1132713dac6c2d72cbb561cf257608b1673894f90a"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80398e9fb598060fa41050d1220f5a2440fe74ff082c36dda41ac3215ebb5ddd"},
+    {file = "grpcio-1.43.0-cp36-cp36m-win32.whl", hash = "sha256:0110310eff07bb69782f53b7a947490268c4645de559034c43c0a635612e250f"},
+    {file = "grpcio-1.43.0-cp36-cp36m-win_amd64.whl", hash = "sha256:45401d00f2ee46bde75618bf33e9df960daa7980e6e0e7328047191918c98504"},
+    {file = "grpcio-1.43.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:af78ac55933811e6a25141336b1f2d5e0659c2f568d44d20539b273792563ca7"},
+    {file = "grpcio-1.43.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8b2b9dc4d7897566723b77422e11c009a0ebd397966b165b21b89a62891a9fdf"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:77ef653f966934b3bfdd00e4f2064b68880eb40cf09b0b99edfa5ee22a44f559"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e95b5d62ec26d0cd0b90c202d73e7cb927c369c3358e027225239a4e354967dc"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:04239e8f71db832c26bbbedb4537b37550a39d77681d748ab4678e58dd6455d6"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b4a7152187a49767a47d1413edde2304c96f41f7bc92cc512e230dfd0fba095"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8cc936a29c65ab39714e1ba67a694c41218f98b6e2a64efb83f04d9abc4386b"},
+    {file = "grpcio-1.43.0-cp37-cp37m-win32.whl", hash = "sha256:577e024c8dd5f27cd98ba850bc4e890f07d4b5942e5bc059a3d88843a2f48f66"},
+    {file = "grpcio-1.43.0-cp37-cp37m-win_amd64.whl", hash = "sha256:138f57e3445d4a48d9a8a5af1538fdaafaa50a0a3c243f281d8df0edf221dc02"},
+    {file = "grpcio-1.43.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:08cf25f2936629db062aeddbb594bd76b3383ab0ede75ef0461a3b0bc3a2c150"},
+    {file = "grpcio-1.43.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:01f4b887ed703fe82ebe613e1d2dadea517891725e17e7a6134dcd00352bd28c"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:0aa8285f284338eb68962fe1a830291db06f366ea12f213399b520c062b01f65"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:0edbfeb6729aa9da33ce7e28fb7703b3754934115454ae45e8cc1db601756fd3"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:c354017819201053d65212befd1dcb65c2d91b704d8977e696bae79c47cd2f82"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50cfb7e1067ee5e00b8ab100a6b7ea322d37ec6672c0455106520b5891c4b5f5"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57f1aeb65ed17dfb2f6cd717cc109910fe395133af7257a9c729c0b9604eac10"},
+    {file = "grpcio-1.43.0-cp38-cp38-win32.whl", hash = "sha256:fa26a8bbb3fe57845acb1329ff700d5c7eaf06414c3e15f4cb8923f3a466ef64"},
+    {file = "grpcio-1.43.0-cp38-cp38-win_amd64.whl", hash = "sha256:ade8b79a6b6aea68adb9d4bfeba5d647667d842202c5d8f3ba37ac1dc8e5c09c"},
+    {file = "grpcio-1.43.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:124e718faf96fe44c98b05f3f475076be8b5198bb4c52a13208acf88a8548ba9"},
+    {file = "grpcio-1.43.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:2f96142d0abc91290a63ba203f01649e498302b1b6007c67bad17f823ecde0cf"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:31e6e489ccd8f08884b9349a39610982df48535881ec34f05a11c6e6b6ebf9d0"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:0e731f660e1e68238f56f4ce11156f02fd06dc58bc7834778d42c0081d4ef5ad"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:1f16725a320460435a8a5339d8b06c4e00d307ab5ad56746af2e22b5f9c50932"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4b4543e13acb4806917d883d0f70f21ba93b29672ea81f4aaba14821aaf9bb0"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:594aaa0469f4fca7773e80d8c27bf1298e7bbce5f6da0f084b07489a708f16ab"},
+    {file = "grpcio-1.43.0-cp39-cp39-win32.whl", hash = "sha256:5449ae564349e7a738b8c38583c0aad954b0d5d1dd3cea68953bfc32eaee11e3"},
+    {file = "grpcio-1.43.0-cp39-cp39-win_amd64.whl", hash = "sha256:bdf41550815a831384d21a498b20597417fd31bd084deb17d31ceb39ad9acc79"},
+    {file = "grpcio-1.43.0.tar.gz", hash = "sha256:735d9a437c262ab039d02defddcb9f8f545d7009ae61c0114e19dda3843febe5"},
+]
+grpcio-status = [
+    {file = "grpcio-status-1.43.0.tar.gz", hash = "sha256:21759006f36a7ffbff187d4191f4118c072d8aa9fa6823a11aad7842a3c6ccd0"},
+    {file = "grpcio_status-1.43.0-py3-none-any.whl", hash = "sha256:9036b24f5769adafdc3e91d9434c20e9ede0b30f50cc6bff105c0f414bb9e0e0"},
+]
+httplib2 = [
+    {file = "httplib2-0.20.2-py3-none-any.whl", hash = "sha256:6b937120e7d786482881b44b8eec230c1ee1c5c1d06bce8cc865f25abbbf713b"},
+    {file = "httplib2-0.20.2.tar.gz", hash = "sha256:e404681d2fbcec7506bcb52c503f2b021e95bee0ef7d01e5c221468a2406d8dc"},
+]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
@@ -229,6 +683,42 @@ idna = [
 more-itertools = [
     {file = "more-itertools-8.8.0.tar.gz", hash = "sha256:83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a"},
     {file = "more_itertools-8.8.0-py3-none-any.whl", hash = "sha256:2cf89ec599962f2ddc4d568a05defc40e0a587fbc10d5989713638864c36be4d"},
+]
+msgpack = [
+    {file = "msgpack-1.0.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:96acc674bb9c9be63fa8b6dabc3248fdc575c4adc005c440ad02f87ca7edd079"},
+    {file = "msgpack-1.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2c3ca57c96c8e69c1a0d2926a6acf2d9a522b41dc4253a8945c4c6cd4981a4e3"},
+    {file = "msgpack-1.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0a792c091bac433dfe0a70ac17fc2087d4595ab835b47b89defc8bbabcf5c73"},
+    {file = "msgpack-1.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c58cdec1cb5fcea8c2f1771d7b5fec79307d056874f746690bd2bdd609ab147"},
+    {file = "msgpack-1.0.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f97c0f35b3b096a330bb4a1a9247d0bd7e1f3a2eba7ab69795501504b1c2c39"},
+    {file = "msgpack-1.0.3-cp310-cp310-win32.whl", hash = "sha256:36a64a10b16c2ab31dcd5f32d9787ed41fe68ab23dd66957ca2826c7f10d0b85"},
+    {file = "msgpack-1.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c1ba333b4024c17c7591f0f372e2daa3c31db495a9b2af3cf664aef3c14354f7"},
+    {file = "msgpack-1.0.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c2140cf7a3ec475ef0938edb6eb363fa704159e0bf71dde15d953bacc1cf9d7d"},
+    {file = "msgpack-1.0.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f4c22717c74d44bcd7af353024ce71c6b55346dad5e2cc1ddc17ce8c4507c6b"},
+    {file = "msgpack-1.0.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d733a15ade190540c703de209ffbc42a3367600421b62ac0c09fde594da6ec"},
+    {file = "msgpack-1.0.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e03b06f2982aa98d4ddd082a210c3db200471da523f9ac197f2828e80e7770"},
+    {file = "msgpack-1.0.3-cp36-cp36m-win32.whl", hash = "sha256:3d875631ecab42f65f9dce6f55ce6d736696ced240f2634633188de2f5f21af9"},
+    {file = "msgpack-1.0.3-cp36-cp36m-win_amd64.whl", hash = "sha256:40fb89b4625d12d6027a19f4df18a4de5c64f6f3314325049f219683e07e678a"},
+    {file = "msgpack-1.0.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6eef0cf8db3857b2b556213d97dd82de76e28a6524853a9beb3264983391dc1a"},
+    {file = "msgpack-1.0.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d8c332f53ffff01953ad25131272506500b14750c1d0ce8614b17d098252fbc"},
+    {file = "msgpack-1.0.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c0903bd93cbd34653dd63bbfcb99d7539c372795201f39d16fdfde4418de43a"},
+    {file = "msgpack-1.0.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bf1e6bfed4860d72106f4e0a1ab519546982b45689937b40257cfd820650b920"},
+    {file = "msgpack-1.0.3-cp37-cp37m-win32.whl", hash = "sha256:d02cea2252abc3756b2ac31f781f7a98e89ff9759b2e7450a1c7a0d13302ff50"},
+    {file = "msgpack-1.0.3-cp37-cp37m-win_amd64.whl", hash = "sha256:2f30dd0dc4dfe6231ad253b6f9f7128ac3202ae49edd3f10d311adc358772dba"},
+    {file = "msgpack-1.0.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:f201d34dc89342fabb2a10ed7c9a9aaaed9b7af0f16a5923f1ae562b31258dea"},
+    {file = "msgpack-1.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bb87f23ae7d14b7b3c21009c4b1705ec107cb21ee71975992f6aca571fb4a42a"},
+    {file = "msgpack-1.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a3a5c4b16e9d0edb823fe54b59b5660cc8d4782d7bf2c214cb4b91a1940a8ef"},
+    {file = "msgpack-1.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f74da1e5fcf20ade12c6bf1baa17a2dc3604958922de8dc83cbe3eff22e8b611"},
+    {file = "msgpack-1.0.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:73a80bd6eb6bcb338c1ec0da273f87420829c266379c8c82fa14c23fb586cfa1"},
+    {file = "msgpack-1.0.3-cp38-cp38-win32.whl", hash = "sha256:9fce00156e79af37bb6db4e7587b30d11e7ac6a02cb5bac387f023808cd7d7f4"},
+    {file = "msgpack-1.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:9b6f2d714c506e79cbead331de9aae6837c8dd36190d02da74cb409b36162e8a"},
+    {file = "msgpack-1.0.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:89908aea5f46ee1474cc37fbc146677f8529ac99201bc2faf4ef8edc023c2bf3"},
+    {file = "msgpack-1.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:973ad69fd7e31159eae8f580f3f707b718b61141838321c6fa4d891c4a2cca52"},
+    {file = "msgpack-1.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da24375ab4c50e5b7486c115a3198d207954fe10aaa5708f7b65105df09109b2"},
+    {file = "msgpack-1.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a598d0685e4ae07a0672b59792d2cc767d09d7a7f39fd9bd37ff84e060b1a996"},
+    {file = "msgpack-1.0.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4c309a68cb5d6bbd0c50d5c71a25ae81f268c2dc675c6f4ea8ab2feec2ac4e2"},
+    {file = "msgpack-1.0.3-cp39-cp39-win32.whl", hash = "sha256:494471d65b25a8751d19c83f1a482fd411d7ca7a3b9e17d25980a74075ba0e88"},
+    {file = "msgpack-1.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:f01b26c2290cbd74316990ba84a14ac3d599af9cebefc543d241a66e785cf17d"},
+    {file = "msgpack-1.0.3.tar.gz", hash = "sha256:51fdc7fb93615286428ee7758cecc2f374d5ff363bdd884c7ea622a7a327a81e"},
 ]
 numpy = [
     {file = "numpy-1.21.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52a664323273c08f3b473548bf87c8145b7513afd63e4ebba8496ecd3853df13"},
@@ -270,9 +760,69 @@ pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
+proto-plus = [
+    {file = "proto-plus-1.19.8.tar.gz", hash = "sha256:bdf45f0e0be71510eb2ec9db4da78afde7b5fb8b0a507a36340a9b6ce8e48e58"},
+    {file = "proto_plus-1.19.8-py3-none-any.whl", hash = "sha256:3434eadaed845a337d6c488d2b7d055d733aaa231c0c0d4c778ec720bb91cf87"},
+]
+protobuf = [
+    {file = "protobuf-3.19.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d80f80eb175bf5f1169139c2e0c5ada98b1c098e2b3c3736667f28cbbea39fc8"},
+    {file = "protobuf-3.19.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a529e7df52204565bcd33738a7a5f288f3d2d37d86caa5d78c458fa5fabbd54d"},
+    {file = "protobuf-3.19.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28ccea56d4dc38d35cd70c43c2da2f40ac0be0a355ef882242e8586c6d66666f"},
+    {file = "protobuf-3.19.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b30a7de128c46b5ecb343917d9fa737612a6e8280f440874e5cc2ba0d79b8f6"},
+    {file = "protobuf-3.19.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5935c8ce02e3d89c7900140a8a42b35bc037ec07a6aeb61cc108be8d3c9438a6"},
+    {file = "protobuf-3.19.1-cp36-cp36m-win32.whl", hash = "sha256:74f33edeb4f3b7ed13d567881da8e5a92a72b36495d57d696c2ea1ae0cfee80c"},
+    {file = "protobuf-3.19.1-cp36-cp36m-win_amd64.whl", hash = "sha256:038daf4fa38a7e818dd61f51f22588d61755160a98db087a046f80d66b855942"},
+    {file = "protobuf-3.19.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e51561d72efd5bd5c91490af1f13e32bcba8dab4643761eb7de3ce18e64a853"},
+    {file = "protobuf-3.19.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:6e8ea9173403219239cdfd8d946ed101f2ab6ecc025b0fda0c6c713c35c9981d"},
+    {file = "protobuf-3.19.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db3532d9f7a6ebbe2392041350437953b6d7a792de10e629c1e4f5a6b1fe1ac6"},
+    {file = "protobuf-3.19.1-cp37-cp37m-win32.whl", hash = "sha256:615b426a177780ce381ecd212edc1e0f70db8557ed72560b82096bd36b01bc04"},
+    {file = "protobuf-3.19.1-cp37-cp37m-win_amd64.whl", hash = "sha256:d8919368410110633717c406ab5c97e8df5ce93020cfcf3012834f28b1fab1ea"},
+    {file = "protobuf-3.19.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:71b0250b0cfb738442d60cab68abc166de43411f2a4f791d31378590bfb71bd7"},
+    {file = "protobuf-3.19.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3cd0458870ea7d1c58e948ac8078f6ba8a7ecc44a57e03032ed066c5bb318089"},
+    {file = "protobuf-3.19.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:655264ed0d0efe47a523e2255fc1106a22f6faab7cc46cfe99b5bae085c2a13e"},
+    {file = "protobuf-3.19.1-cp38-cp38-win32.whl", hash = "sha256:b691d996c6d0984947c4cf8b7ae2fe372d99b32821d0584f0b90277aa36982d3"},
+    {file = "protobuf-3.19.1-cp38-cp38-win_amd64.whl", hash = "sha256:e7e8d2c20921f8da0dea277dfefc6abac05903ceac8e72839b2da519db69206b"},
+    {file = "protobuf-3.19.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fd390367fc211cc0ffcf3a9e149dfeca78fecc62adb911371db0cec5c8b7472d"},
+    {file = "protobuf-3.19.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d83e1ef8cb74009bebee3e61cc84b1c9cd04935b72bca0cbc83217d140424995"},
+    {file = "protobuf-3.19.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36d90676d6f426718463fe382ec6274909337ca6319d375eebd2044e6c6ac560"},
+    {file = "protobuf-3.19.1-cp39-cp39-win32.whl", hash = "sha256:e7b24c11df36ee8e0c085e5b0dc560289e4b58804746fb487287dda51410f1e2"},
+    {file = "protobuf-3.19.1-cp39-cp39-win_amd64.whl", hash = "sha256:77d2fadcf369b3f22859ab25bd12bb8e98fb11e05d9ff9b7cd45b711c719c002"},
+    {file = "protobuf-3.19.1-py2.py3-none-any.whl", hash = "sha256:e813b1c9006b6399308e917ac5d298f345d95bb31f46f02b60cd92970a9afa17"},
+    {file = "protobuf-3.19.1.tar.gz", hash = "sha256:62a8e4baa9cb9e064eb62d1002eca820857ab2138440cb4b3ea4243830f94ca7"},
+]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pyasn1-modules = [
+    {file = "pyasn1-modules-0.2.8.tar.gz", hash = "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e"},
+    {file = "pyasn1_modules-0.2.8-py2.4.egg", hash = "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199"},
+    {file = "pyasn1_modules-0.2.8-py2.5.egg", hash = "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"},
+    {file = "pyasn1_modules-0.2.8-py2.6.egg", hash = "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb"},
+    {file = "pyasn1_modules-0.2.8-py2.7.egg", hash = "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8"},
+    {file = "pyasn1_modules-0.2.8-py2.py3-none-any.whl", hash = "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"},
+    {file = "pyasn1_modules-0.2.8-py3.1.egg", hash = "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d"},
+    {file = "pyasn1_modules-0.2.8-py3.2.egg", hash = "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45"},
+    {file = "pyasn1_modules-0.2.8-py3.3.egg", hash = "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4"},
+    {file = "pyasn1_modules-0.2.8-py3.4.egg", hash = "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811"},
+    {file = "pyasn1_modules-0.2.8-py3.5.egg", hash = "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed"},
+    {file = "pyasn1_modules-0.2.8-py3.6.egg", hash = "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0"},
+    {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -289,6 +839,18 @@ python-dotenv = [
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
+rsa = [
+    {file = "rsa-4.8-py3-none-any.whl", hash = "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"},
+    {file = "rsa-4.8.tar.gz", hash = "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+uritemplate = [
+    {file = "uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e"},
+    {file = "uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ numpy = "^1.21.2"
 click = "^8.0.1"
 python-dotenv = "^0.19.2"
 requests = "^2.26.0"
+firebase-admin = "^5.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
対戦を走らせる度にELO比較画面 http://quarto.unigiri.net/ をリロードすることが面倒なため、データの保存先を容易にリアルタイム更新可能なFirestoreに変更する

DBに保存するデータの変更は無く、従来通り `AIの名前` と `ELO` の2種類のみ

挙動は https://github.com/unigiriunini/Ktuarto/actions/workflows/battle_between_AIs.yml で確認可能